### PR TITLE
Fixed the potential bug when calling compton with more than 1 argument

### DIFF
--- a/comptray
+++ b/comptray
@@ -133,7 +133,8 @@ def togglecompton(data=None):
     if comptonisrunning():
         call(["pkill", "compton"])
     else:
-        call(["compton", arguments])
+        cmd = 'compton ' + arguments
+        call(cmd.split(' '))
         print('Launched \"compton '+arguments+"\"") 
 	
 def check_for_update():		

--- a/comptray
+++ b/comptray
@@ -104,6 +104,10 @@ def openargedit(data=None):
     #Get arguments
     arguments = entry.get_text()
     dialog.destroy()
+    saveconfig()
+    if comptonisrunning():
+        togglecompton()
+        togglecompton()
 
 def comptonisrunning():
         try:


### PR DESCRIPTION
When calling compton with multiple arguments call() would loose all of them, and this would result in failure to start compton by click.
Example:
--vsync=opengl --unredir-if-possible --paint-on-overlay --glx-no-stencil -CGb
 would try and process all what goes after opengl as an extension of --vsync.  
